### PR TITLE
Fix build command for gradle 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Android resources have dependencies to each other. This means that after running
 
 e.g.
 
-    ./gradlew clean build :lint && android-resource-remover --xml build/outputs/lint-results.xml
+    ./gradlew clean build && android-resource-remover --xml build/outputs/lint-results.xml
 
 
 ### Options


### PR DESCRIPTION
Build failed with gradle 2.2.1:
# ./gradlew clean build :lint

FAILURE: Build failed with an exception.
- What went wrong:
  Task 'lint' not found in root project 'xxx'. Some candidates are: 'init'.

BUILD FAILED
